### PR TITLE
test: mock expo-router in jest setup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,6 +22,21 @@ jest.mock('expo-localization', () => ({
   getLocales: () => [{ languageCode: 'ja' }],
 }));
 
+jest.mock('expo-router', () => {
+  const React = require('react');
+
+  return {
+    useRouter: () => ({
+      back: jest.fn(),
+      push: jest.fn(),
+      replace: jest.fn(),
+      canGoBack: jest.fn(() => false),
+    }),
+    Stack: ({ children }) => React.createElement(React.Fragment, null, children),
+    Link: ({ children }) => React.createElement(React.Fragment, null, children),
+  };
+});
+
 const i18n = require('i18next');
 const { initReactI18next } = require('react-i18next');
 const enCommon = require('./src/locales/en/common.json');


### PR DESCRIPTION
Closes #5

## Summary
- Stabilize tests by mocking expo-router in Jest setup.\n- Prevent router runtime differences from breaking ErrorState tests.

## Test
- npm test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to improve routing and component mocking in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->