### PR TITLE
fix: narrow JSON imports to typed content models

### DIFF
--- a/src/content/cards.ts
+++ b/src/content/cards.ts
@@ -23,10 +23,15 @@ import textsEn from '../../content/cards/04_texts.en.json';
 import uxJa from '../../content/cards/05_app_integration.ja.json';
 import uxEn from '../../content/cards/05_app_integration.en.json';
 
+// JSON imports are structurally compatible but typed as broad string fields.
+// Narrow them once at the boundary.
+const jaPacks = [coreJa, peopleJa, practiceJa, mandalaJa, textsJa, uxJa] as CardPackJson[];
+const enPacks = [coreEn, peopleEn, practiceEn, mandalaEn, textsEn, uxEn] as CardPackJson[];
+
 // Static registry of packs per language. / 言語別パックの静的レジストリ。
 const PACKS_BY_LANG: Record<ContentLang, CardPackJson[]> = {
-  ja: [coreJa, peopleJa, practiceJa, mandalaJa, textsJa, uxJa],
-  en: [coreEn, peopleEn, practiceEn, mandalaEn, textsEn, uxEn],
+  ja: jaPacks,
+  en: enPacks,
 };
 
 export type CardPackSummary = {

--- a/src/content/glossary.ts
+++ b/src/content/glossary.ts
@@ -13,10 +13,13 @@ import type { ContentLang } from './lang';
 import glossaryJa from '../../content/glossary/glossary.ja.json';
 import glossaryEn from '../../content/glossary/glossary.en.json';
 
+const glossaryJaData = glossaryJa as GlossaryJson;
+const glossaryEnData = glossaryEn as GlossaryJson;
+
 // Static glossary data registry by language. / 言語別の静的用語集レジストリ。
 const GLOSSARY_BY_LANG: Record<ContentLang, GlossaryJson> = {
-  ja: glossaryJa,
-  en: glossaryEn,
+  ja: glossaryJaData,
+  en: glossaryEnData,
 };
 
 // Overload: default language when none provided. / 言語未指定時は既定言語。


### PR DESCRIPTION
Closes #6

## Summary
- Add explicit type narrowing for content JSON imports.\n- Resolve strict TypeScript assignment issues in content loaders.

## Test
- npx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal content management with improved type safety and code organization for language-specific data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->