### PR TITLE
chore: add missing reset-project script

### DIFF
--- a/scripts/reset-project.js
+++ b/scripts/reset-project.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_ROOT = process.cwd();
+const TARGETS = ['.expo', '.expo-shared', '.turbo'];
+
+for (const target of TARGETS) {
+  const fullPath = path.join(PROJECT_ROOT, target);
+  if (!fs.existsSync(fullPath)) continue;
+  fs.rmSync(fullPath, { recursive: true, force: true });
+  console.log(`Removed ${target}`);
+}
+
+console.log('Project cache reset completed.');


### PR DESCRIPTION
Closes #7

## Summary
- Add missing scripts/reset-project.js referenced by package scripts.\n- Clear local app cache/state directories used by dev workflows.

## Test
- npm run reset-project