### PR TITLE
fix: reset synced entry state locally and remotely

### DIFF
--- a/__tests__/reset.test.ts
+++ b/__tests__/reset.test.ts
@@ -3,10 +3,27 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { KEY_LAST_ACTIVE_DATE } from '../src/lib/engagement';
 import { KEY_START_DATE } from '../src/lib/programDay';
 import { resetAllProgress } from '../src/lib/reset';
+import { entryStore } from '../src/storage/entryStore';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
+
+jest.mock('../src/storage/entryStore', () => ({
+  entryStore: {
+    clearAll: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../src/lib/supabase', () => ({
+  isSupabaseConfigured: false,
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(),
+  },
+}));
 
 describe('resetAllProgress', () => {
   beforeEach(async () => {
@@ -29,5 +46,6 @@ describe('resetAllProgress', () => {
     await expect(AsyncStorage.getItem('morningLog:2025-01-03')).resolves.toBeNull();
     await expect(AsyncStorage.getItem('nightLog:2025-01-03')).resolves.toBeNull();
     await expect(AsyncStorage.getItem('other:key')).resolves.toBe('keep');
+    expect(entryStore.clearAll).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/reset.ts
+++ b/src/lib/reset.ts
@@ -10,6 +10,8 @@
 import { KEY_LAST_ACTIVE_DATE } from './engagement';
 import { KEY_START_DATE } from './programDay';
 import { getAllKeys, multiRemove } from './storage';
+import { entryStore } from '../storage/entryStore';
+import { isSupabaseConfigured, supabase } from './supabase';
 
 // Prefixes for per-day logs to clear. / 日次ログ削除対象の接頭辞。
 const KEY_PREFIXES = ['todayLog:action:', 'morningLog:', 'nightLog:'];
@@ -22,5 +24,21 @@ export async function resetAllProgress(): Promise<void> {
     return KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
   });
 
-  await multiRemove(target);
+  await Promise.all([multiRemove(target), entryStore.clearAll()]);
+
+  // Best-effort remote purge when sync/account is enabled.
+  if (!isSupabaseConfigured) return;
+  try {
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) return;
+    const { error } = await supabase.from('entries').delete().eq('user_id', user.id);
+    if (error) {
+      console.warn('Failed to delete remote entries during reset.', error);
+    }
+  } catch (err) {
+    console.warn('Failed to run remote reset cleanup.', err);
+  }
 }

--- a/src/storage/entryStore.native.ts
+++ b/src/storage/entryStore.native.ts
@@ -164,4 +164,12 @@ export const entryStore: EntryStore = {
       [value],
     );
   },
+
+  async clearAll() {
+    const db = await getDb();
+    await db.execAsync(`
+      delete from entries;
+      delete from meta;
+    `);
+  },
 };

--- a/src/storage/entryStore.types.ts
+++ b/src/storage/entryStore.types.ts
@@ -36,4 +36,5 @@ export interface EntryStore {
   markClean(key: { date: string; slot: EntrySlot }, serverUpdatedAt: string): Promise<void>;
   getLastSyncAt(): Promise<string | null>;
   setLastSyncAt(value: string): Promise<void>;
+  clearAll(): Promise<void>;
 }

--- a/src/storage/entryStore.web.ts
+++ b/src/storage/entryStore.web.ts
@@ -76,4 +76,11 @@ export const entryStore: EntryStore = {
     if (!db) return;
     await db.put('meta', value, 'last_sync_at');
   },
+
+  async clearAll() {
+    const db = await getDb();
+    if (!db) return;
+    await db.clear('entries');
+    await db.clear('meta');
+  },
 };


### PR DESCRIPTION
Closes #10

## Summary
- Add clearAll() to entry store interface and implementations.\n- Extend reset flow to clear synced local data and best-effort remote data.

## Test
- npm test -- --runInBand __tests__/reset.test.ts