### PR TITLE
fix: persist consistent noteVersion for night entries

### DIFF
--- a/src/app/(tabs)/night.tsx
+++ b/src/app/(tabs)/night.tsx
@@ -291,7 +291,7 @@ export default function NightScreen() {
                 speechDone: hotsuganDone,
                 mindDone: ekouDone,
                 noteCiphertext,
-                noteVersion: noteCiphertext ? 0 : 1,
+                noteVersion: 1,
               }).catch((err) => {
                 console.warn('Failed to sync night entry.', err);
               });


### PR DESCRIPTION
Closes #12

## Summary
- Always persist night note entries with noteVersion=1.\n- Remove mixed version writes that caused inconsistency.

## Test
- npm test -- --runInBand __tests__/nightLog.test.ts