### PR TITLE
style: use T[] syntax in entry store interface

### DIFF
--- a/src/storage/entryStore.types.ts
+++ b/src/storage/entryStore.types.ts
@@ -32,7 +32,7 @@ export interface EntryStore {
   upsertLocal(entry: Entry): Promise<void>;
   listByDate(date: string): Promise<Entry[]>;
   listDirty(): Promise<Entry[]>;
-  applyRemote(entries: Array<Omit<Entry, 'isDirty'>>): Promise<void>;
+  applyRemote(entries: Omit<Entry, 'isDirty'>[]): Promise<void>;
   markClean(key: { date: string; slot: EntrySlot }, serverUpdatedAt: string): Promise<void>;
   getLastSyncAt(): Promise<string | null>;
   setLastSyncAt(value: string): Promise<void>;


### PR DESCRIPTION
Closes #13

## Summary
- Replace Array<T> with T[] in entryStore types.\n- Remove lint warning while keeping behavior unchanged.

## Test
- npm run lint